### PR TITLE
Show current theme in the prompt, and select it

### DIFF
--- a/helm-themes.el
+++ b/helm-themes.el
@@ -57,9 +57,14 @@
         (orig-theme (when custom-enabled-themes
                       (car custom-enabled-themes))))
     (unwind-protect
-        (progn
-          (when (helm :sources helm-themes-source :buffer "*helm-themes*")
-            (setq changed t)))
+        (when (helm :prompt (format "pattern (current theme: %s): "
+                                    (if (null custom-enabled-themes)
+                                        'default
+                                      (symbol-name orig-theme)))
+                    :preselect (format "%s$" (symbol-name orig-theme))
+                    :sources helm-themes-source
+                    :buffer "*helm-themes*")
+          (setq changed t))
       (when (not changed)
         (helm-themes--delete-theme)
         (when orig-theme


### PR DESCRIPTION
- `progn` was removed because it didn't seem to be needed, and it works fine without it.
- `$` at the end of the `:preselect` string, ensures that only the exact theme name gets selected. Otherwise, when for example the current theme is `tango`, then `tango-dark` gets selected in the default themes list, because it's listed first.

This resolves #5.